### PR TITLE
Adding "msg_minutes_until" to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Added missing doc for "msg_minutes_until"
 
 ## [v0.5.0](https://github.com/stefanlogue/hydrate.nvim/releases/tag/v0.5.0) - 2024-07-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ This is a list of the options that can be passed to `require("hydrate").setup()`
 
   -- Sets the message after acknowledging the reminder to the 
   -- specified message
-  msg_hydrated = " 💧 You've had a drink, timer reset 💧"
+  msg_hydrated = " 💧 You've had a drink, timer reset 💧",
+
+  -- Sets text displayed before time in minutes for
+  -- ":HydrateWhen" message
+  msg_minutes_until = "Drink due in",
 }
 ```
 


### PR DESCRIPTION
Hi again. Thanks for merging my last little change! I noticed, that I didn't include `msg_minutes_until` in the README.
This PR fixes that.